### PR TITLE
Fix for detecting EAC version of modified logs

### DIFF
--- a/eac.py
+++ b/eac.py
@@ -45,12 +45,13 @@ def eac_checksum(text):
 
 
 def extract_info(text):
-    version = text.splitlines()[0]
+    version = None
 
-    if not version.startswith('Exact Audio Copy'):
-        version = None
-    else:
-        version = tuple(version.split()[3:6])
+    for line in text.splitlines():
+        if line.startswith('Exact Audio Copy'):
+            version = tuple(line.split()[3:6])
+        elif re.match(r'[a-zA-Z]', line):
+            break
 
     if '\r\n\r\n==== Log checksum' not in text:
         signature = None

--- a/eac.py
+++ b/eac.py
@@ -3,6 +3,7 @@
 import sys
 import argparse
 import contextlib
+import re
 
 import pprp
 


### PR DESCRIPTION
Spotted this [log file](https://github.com/puddly/eac_logsigner/files/2608243/26.log) out in the wild. The official EAC reports this as a modified checksum while yours declares it has no checksum. It appears that EAC is fine with the version not appearing on the first line of the log. I'm not sure if there's ever a case where this would happen in a valid log, rendering the actual checksum validation unnecessary though.

You could probably do away with the dependency on the `re` module, but I plan to submit subsequent patches that make use of it.